### PR TITLE
Run broken link checks during CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,7 @@ node('docker&&linux') {
         */
         if (!infra.isTrusted() && env.BRANCH_NAME != null) {
             sh 'make check'
+            sh 'make check-broken-links'
             recordIssues(tools: [checkStyle(id: 'typos', name: 'Typos', pattern: 'checkstyle.xml')],
                          qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]])
         }


### PR DESCRIPTION
## Summary
- run `make check-broken-links` in the CI Checks stage
- fail the build if broken links are found

## Testing
- `make check` *(fails: CONNECT tunnel failed)*
- `make check-broken-links` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c03e7988321b36c1f17789b1c80